### PR TITLE
Project API adaptations

### DIFF
--- a/src/main/java/at/medunigraz/damap/rest/dmp/domain/MUGProject.java
+++ b/src/main/java/at/medunigraz/damap/rest/dmp/domain/MUGProject.java
@@ -42,4 +42,6 @@ public class MUGProject {
     // "<organizationID>-<personID>-<projectRoleID>"
     @JsonSetter(nulls = Nulls.AS_EMPTY)
     private List<String> persons;
+
+    private String manager;
 }

--- a/src/main/java/at/medunigraz/damap/rest/dmp/domain/MUGProject.java
+++ b/src/main/java/at/medunigraz/damap/rest/dmp/domain/MUGProject.java
@@ -1,6 +1,7 @@
 package at.medunigraz.damap.rest.dmp.domain;
 
 import java.util.Date;
+import java.util.List;
 
 import javax.validation.constraints.Size;
 
@@ -36,4 +37,9 @@ public class MUGProject {
     @JsonProperty(value = "end_effective")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
     private Date endDate;
+
+    // List of person IDs with prefix and suffix. Format:
+    // "<organizationID>-<personID>-<projectRoleID>"
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    private List<String> persons;
 }

--- a/src/main/java/at/medunigraz/damap/rest/projects/MUGProjectRestService.java
+++ b/src/main/java/at/medunigraz/damap/rest/projects/MUGProjectRestService.java
@@ -1,5 +1,7 @@
 package at.medunigraz.damap.rest.projects;
 
+import java.time.Instant;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -17,6 +19,7 @@ public interface MUGProjectRestService extends MUGAPIServiceBase<MUGProject> {
     @Path("")
     @ClientHeaderParam(name = "accept", value = "application/json")
     // TODO: Can not filter for title yet.
-    MUGSearchResult<MUGProject> search(@QueryParam("title__contains") String title, @QueryParam("offset") int offset,
+    MUGSearchResult<MUGProject> search(@QueryParam("title") String title,
+            @QueryParam("end_effective__gte") Instant endEffective, @QueryParam("offset") int offset,
             @QueryParam("limit") int limit);
 }

--- a/src/main/java/at/medunigraz/damap/rest/projects/MUGProjectServiceImpl.java
+++ b/src/main/java/at/medunigraz/damap/rest/projects/MUGProjectServiceImpl.java
@@ -17,7 +17,6 @@ import at.ac.tuwien.damap.rest.dmp.domain.ContributorDO;
 import at.ac.tuwien.damap.rest.dmp.domain.ProjectDO;
 import at.ac.tuwien.damap.rest.projects.ProjectService;
 import at.ac.tuwien.damap.rest.projects.ProjectSupplementDO;
-import at.medunigraz.damap.rest.dmp.domain.MUGPerson;
 import at.medunigraz.damap.rest.dmp.domain.MUGProject;
 import at.medunigraz.damap.rest.dmp.mapper.MUGPersonDOMapper;
 import at.medunigraz.damap.rest.dmp.mapper.MUGProjectDOMapper;
@@ -70,8 +69,6 @@ public class MUGProjectServiceImpl implements ProjectService {
         var persons = Uni.join().all(unis.collect(Collectors.toList())).andCollectFailures()
                 .await().atMost(Duration.ofSeconds(10));
 
-        log.info(persons);
-
         return persons.stream().map(mugPerson -> MUGPersonDOMapper.mapEntityToDO(mugPerson, new ContributorDO()))
                 .collect(Collectors.toList());
     }
@@ -98,6 +95,11 @@ public class MUGProjectServiceImpl implements ProjectService {
 
     @Override
     public ContributorDO getProjectLeader(String projectId) {
-        return null;
+        MUGProject project = projectRestService.read(projectId, null);
+        if (project.getManager() == null) {
+            return null;
+        }
+
+        return MUGPersonDOMapper.mapEntityToDO(personRestService.read(project.getManager(), null), new ContributorDO());
     }
 }

--- a/src/main/java/at/medunigraz/damap/rest/projects/MUGProjectServiceImpl.java
+++ b/src/main/java/at/medunigraz/damap/rest/projects/MUGProjectServiceImpl.java
@@ -1,5 +1,6 @@
 package at.medunigraz.damap.rest.projects;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,7 +40,7 @@ public class MUGProjectServiceImpl implements ProjectService {
         int offset = ((s.getPagination().getPage() < 1 ? 1 : s.getPagination().getPage()) - 1) * limit;
 
         try {
-            var mugProjects = projectRestService.search(s.getQuery(), offset, limit);
+            var mugProjects = projectRestService.search(s.getQuery(), new Date().toInstant(), offset, limit);
 
             projects = mugProjects.getResults().stream().map(p -> MUGProjectDOMapper.mapEntityToDO(p, new ProjectDO()))
                     .collect(Collectors.toList());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,8 +20,8 @@ damap:
   repositories:
     # Zenodo, Open Science Framework, DRYAD, Mendeley Data
     recommendation: ['r3d100010468', 'r3d100011137', 'r3d100000044', 'r3d100011868'] # your-recommended-repositories
-  projects-url: https://api.medunigraz.at/v1/research/project
-  persons-url: https://api.medunigraz.at/v1/campusonline/person
+  projects-url: https://api-test.medunigraz.at/v1/research/project
+  persons-url: https://api-test.medunigraz.at/v1/campusonline/person
   fits-url: http://fits-service:8080/fits
   person-services:
     - display-text: 'University'


### PR DESCRIPTION
closes #4 

Set filter for project search to only include projects matching the search term and with an end in the future.

Fetch persons involved in the project. This info is available in the project. The persons should be fetched concurrently (i.e. a request is sent before waiting for the last request to finish. Instead, all requests are collected at the end). This should improve performance, if the remote API is slow.