### PR TITLE
:truck: rename: docker image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ FROM maven:3.9.5-eclipse-temurin-17-alpine as builder
 LABEL maintainer="rdmteam@tugraz.at" \
         org.label-schema.name="DAMAP-backend" \
         org.label-schema.description="DAMAP is a tool that aims to facilitate the creation of data management plans (DMPs) for researchers." \
-        org.label-schema.usage="https://github.com/sharedRDM/damap-backend/tree/main/doc" \
+        org.label-schema.usage="https://github.com/sharedRDM/damap-backend-mug/tree/main/doc" \
         org.label-schema.vendor="Technische Universität Graz" \
-        org.label-schema.url="https://github.com/sharedRDM/damap-backend" \
-        org.label-schema.vcs-url="https://github.com/sharedRDM/damap-backend" \
+        org.label-schema.url="https://github.com/sharedRDM/damap-backend-mug" \
+        org.label-schema.vcs-url="https://github.com/sharedRDM/damap-backend-mug" \
         org.label-schema.schema-version="1.0" \
         org.label-schema.docker.cmd="docker run -d -p 8080:8080 damap"
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -74,5 +74,5 @@ The OpenAPI documentation is automatically generated for the backend. Additional
 
 ## MUG API
 
-For the Medical University of Graz (MUG) environment, the relevant API information can be found in the [application.yaml](https://github.com/sharedRDM/damap-backend/blob/4fe538bddda793ebdfd7a883ba0cd3764e32ef79/src/main/resources/application.yaml#L23-L24) file.
-MUG also uses an authentication token in their configuration for the API, which can be found [here](https://github.com/sharedRDM/damap-backend/blob/4fe538bddda793ebdfd7a883ba0cd3764e32ef79/src/main/resources/application.yaml#L34-L37).
+For the Medical University of Graz (MUG) environment, the relevant API information can be found in the [application.yaml](https://github.com/sharedRDM/damap-backend-mug/blob/4fe538bddda793ebdfd7a883ba0cd3764e32ef79/src/main/resources/application.yaml#L23-L24) file.
+MUG also uses an authentication token in their configuration for the API, which can be found [here](https://github.com/sharedRDM/damap-backend-mug/blob/4fe538bddda793ebdfd7a883ba0cd3764e32ef79/src/main/resources/application.yaml#L34-L37).

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A tool for machine actionable DMPs.</description>
-  <url>https://github.com/sharedRDM/damap-backend</url>
+  <url>https://github.com/sharedRDM/damap-backend-mug</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
Renamed Docker image references from damap-backend to damap-backend-mug in:
 pom.xml, INSTALLATION.md, and Dockerfile, updating URLs to https://github.com/sharedRDM/damap-backend-mug